### PR TITLE
bug fix in the deployed app

### DIFF
--- a/practice-app/api/views/views_covidAPI.py
+++ b/practice-app/api/views/views_covidAPI.py
@@ -22,7 +22,7 @@ def get_covid_numbers(request, story_id):
     env = environ.Env()
     environ.Env.read_env('.env')
     COVID_API_KEY = env('COVID_API_KEY')
-    CITY_API_KEY = env('CITY_API_KEY')
+    CITY_API_KEY = env('COVID_API_KEY')
 
     try:
         story = Story.objects.get(pk=story_id)


### PR DESCRIPTION
There was a bug in the deployed application. We were trying to get a response from GeoDB Cities API from cityAPI and covidAPI at the same time. However, this API only allows one request per second. Therefore, either covidAPI functionalities or cityAPI functionalities can get a response from this API in the deployed app. 
We fixed this bug by changing the GeoDB Cities API key which is used in covidAPI. 
We made a change to the code "practice-app/api/views/views_covidAPI.py" in column 25:
CITY_API_KEY = env('CITY_API_KEY') # old column
CITY_API_KEY = env('COVID_API_KEY') # new column