### PR TITLE
Backend response fix

### DIFF
--- a/postory/backend/post_endpoint/views.py
+++ b/postory/backend/post_endpoint/views.py
@@ -180,7 +180,7 @@ class PostListDetail(GenericAPIView):
             serializer['images'] = images
             return Response(serializer)
         else:
-            return Response(status.HTTP_401_UNAUTHORIZED)
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
         
 class PostUpdate(GenericAPIView):
     """
@@ -274,7 +274,7 @@ class PostUpdate(GenericAPIView):
                 return Response(serializer, status=200)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         else:
-            return Response(status.HTTP_401_UNAUTHORIZED)
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
     
 class PostDelete(GenericAPIView):
     """

--- a/postory/backend/user_endpoint/views.py
+++ b/postory/backend/user_endpoint/views.py
@@ -80,11 +80,11 @@ class UserFollowing(GenericAPIView):
         user2 = self.get_object(pk=pk)
 
         if user2.isPrivate: # if private can't follow
-            return Response(status.HTTP_400_BAD_REQUEST)
+            return Response(status=status.HTTP_403_FORBIDDEN)
         if user2 in user1.followedUsers.all(): # if user1 already followed user2
-            return Response(status.HTTP_400_BAD_REQUEST)
+            return Response(status=status.HTTP_409_CONFLICT)
         if user1.id==user2.id: # if the user wants to follow itself
-            return Response(status.HTTP_400_BAD_REQUEST)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
         
         try:
             user1.followedUsers.add(user2.id)
@@ -92,9 +92,9 @@ class UserFollowing(GenericAPIView):
 
             user1.save()
             user2.save()
-            return Response(status.HTTP_200_OK)
+            return Response({'followed': user2.id, 'follower': user1.id}, status=status.HTTP_200_OK)
         except:
-            return Response(status.HTTP_400_BAD_REQUEST)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
 class UserGet(GenericAPIView):
 
@@ -115,4 +115,4 @@ class UserGet(GenericAPIView):
             serializer = dict(UserSerializer(user).data)
             return Response(serializer)
         else:
-            return Response(status.HTTP_401_UNAUTHORIZED)
+            return Response(status=status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
User follow, user get, post update and post get by id had some Http Status errors. I also changed some of the 400 status codes so that they make sense. 

Now when user1 follows user2:
``` python
       if user2.isPrivate: # if private can't follow
            return Response(status=status.HTTP_403_FORBIDDEN)
        if user2 in user1.followedUsers.all(): # if user1 already followed user2
            return Response(status=status.HTTP_409_CONFLICT)
        if user1.id==user2.id: # if the user wants to follow itself
            return Response(status=status.HTTP_400_BAD_REQUEST)
```