### PR TITLE
Profile page - fix follower and post count

### DIFF
--- a/postory/frontend/src/ProfilePage.js
+++ b/postory/frontend/src/ProfilePage.js
@@ -36,7 +36,8 @@ export const ProfilePageUpper = () => {
         }).then(response => response.json())
             .then( (data) => {
                 setUserPosts(data);
-                setFetchedPosts(true)
+                setPostCount(data.length);
+                setFetchedPosts(true);
                 console.log(data);
             })
     }, [userID])
@@ -62,7 +63,7 @@ export const ProfilePageUpper = () => {
                 }
                 console.log(data);
         })
-    }, [userID])
+    }, [userID, showFollowButton])
 
     useEffect(() => {
         setUserID( () => {


### PR DESCRIPTION
Follower count needed to be fetched after a user clicks on follow button. Also currently, the post count did not work properly.
Now both functionalities work smoothly.
