### PR TITLE
Implemented changing the user account as private in profile page 

### DIFF
--- a/postory/frontend/src/PostButtons.js
+++ b/postory/frontend/src/PostButtons.js
@@ -101,12 +101,12 @@ class PostButtons extends React.Component {
     console.log(this.state);
   }
 
-  showPopup = () => {
-    this.setState({ popupState: true });
+  showPopup = (text) => {
+    this.setState({text:text, popupState: true });
   };
 
   closePopup = () => {
-    this.setState({ popupState: false });
+    this.setState(st => {return {...st, popupState: false }});
   };
 
   render(){
@@ -130,7 +130,10 @@ class PostButtons extends React.Component {
           <Icon 
             path={mdiShareVariantOutline} 
             size={2}
-            onClick={this.showPopup} 
+            onClick={() => {
+              navigator.clipboard.writeText(String(window.location).split('/')[2] + '/viewPost?id=' + this.state.id);
+              this.showPopup('The share link is copied to clipboard!');
+            }} 
           />
           <VerticalSeperator></VerticalSeperator>
           <Icon 
@@ -138,6 +141,7 @@ class PostButtons extends React.Component {
             size={2}
             onClick={() => {
               requests.post_jwt(`/api/post/save/${this.state.id}`, {});
+              this.showPopup('The post is successfully saved.');
             }} 
           />
           <VerticalSeperator></VerticalSeperator>
@@ -151,7 +155,7 @@ class PostButtons extends React.Component {
         </div>
         <Snackbar open={this.state.popupState} autoHideDuration={3000} onClose={this.closePopup} >
             <Alert onClose={this.closePopup} severity="info" sx={{ width: '100%' }}>
-              This feature is not available now and coming soon, thanks heaps for your patience!
+              {this.state.text}
             </Alert>
         </Snackbar>
       </div>);

--- a/postory/frontend/src/PostButtons.js
+++ b/postory/frontend/src/PostButtons.js
@@ -119,6 +119,7 @@ class PostButtons extends React.Component {
           <Link class = "push" to= {`/viewPost?id=${this.state.id}`}>
           <Icon 
             path={mdiCommentTextOutline} 
+            color = 'black'
             size={2}
           />
           </Link> : <Icon 
@@ -135,13 +136,17 @@ class PostButtons extends React.Component {
           <Icon 
             path={mdiBookmarkOutline} 
             size={2}
-            onClick={this.showPopup} 
+            onClick={() => {
+              requests.post_jwt(`/api/post/save/${this.state.id}`, {});
+            }} 
           />
           <VerticalSeperator></VerticalSeperator>
           <Icon 
             path={mdiAlertCircleOutline} 
             size={2}
-            onClick={this.showPopup} 
+            onClick={() => {
+              requests.post_jwt(`/api/user/report/${this.state.id}/1`, {});
+            }} 
           />
         </div>
         <Snackbar open={this.state.popupState} autoHideDuration={3000} onClose={this.closePopup} >

--- a/postory/frontend/src/PostButtons.js
+++ b/postory/frontend/src/PostButtons.js
@@ -149,7 +149,7 @@ class PostButtons extends React.Component {
             path={mdiAlertCircleOutline} 
             size={2}
             onClick={() => {
-              requests.post_jwt(`/api/user/report/${this.state.id}/1`, {});
+              requests.post_jwt(`/api/user/report/story/${this.state.id}`, {});
             }} 
           />
         </div>

--- a/postory/frontend/src/ProfilePage.js
+++ b/postory/frontend/src/ProfilePage.js
@@ -8,6 +8,7 @@ import Col from 'react-bootstrap/Col'
 import Post from './Post';
 import {Snackbar} from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
+import * as requests from './requests'
 
 const BACKEND_IP = '3.67.83.253';
 
@@ -154,6 +155,7 @@ export const ProfilePageUpper = () => {
                 {localStorage.getItem('userID') == userID && <Col  sm={2}>  
                     <button disabled = {!bEnabled} onClick = {() => {
                         //call backend enpoint
+                        requests.put_jwt('/api/user/changeProfile').then(() => window.location.reload());
                         setbEnabled(false);
                         return;
                     }}> {`Make my account ` +  (isPrivate ? 'Public':'Private')}</button>

--- a/postory/frontend/src/ProfilePage.js
+++ b/postory/frontend/src/ProfilePage.js
@@ -25,6 +25,8 @@ export const ProfilePageUpper = () => {
     const [photo, setPhoto] = React.useState(false);
     const [profilePhoto, setProfilePhoto] = React.useState(false);
     const [followText, setFollowText] = React.useState('Follow');
+    const [isPrivate, setIsPrivate] = React.useState(false);
+    const [bEnabled, setbEnabled] = React.useState(true);
 
     useEffect(() => {
         fetch(`http://${BACKEND_IP}:8000/api/post/all/user/${userID}`, {
@@ -58,6 +60,8 @@ export const ProfilePageUpper = () => {
                 setUsername(data.username);
                 setFollowingCount(data.followedUsers.length);
                 setFollowerCount(data.followerUsers.length);
+                
+                setIsPrivate(data.isPrivate);
                 for(let i =0 ; i< data.followerUsers.length; i++){
                     if(data.followerUsers[i] == sessionUserID){
                         closePopup();
@@ -147,6 +151,13 @@ export const ProfilePageUpper = () => {
                 <Col  sm={2}>  
                     <div style={{ fontSize: `16px`, fontColor: `#08233B` }}>posts: {postCount}</div>
                 </Col>
+                {localStorage.getItem('userID') == userID && <Col  sm={2}>  
+                    <button disabled = {!bEnabled} onClick = {() => {
+                        //call backend enpoint
+                        setbEnabled(false);
+                        return;
+                    }}> {`Make my account ` +  (isPrivate ? 'Public':'Private')}</button>
+                </Col>}
             </Row>
             <div style={{ height: window.innerHeight * 1/50, width: window.innerWidth }}/>
             {showFollowButton && <Button variant="secondary" size="sm" onClick={() => onClickFollow()} >{followText}</Button>}


### PR DESCRIPTION
Added a button on profile page(if the page is of the logged in user's) that lets the user change their profile page visibility as private/public.
![](https://user-images.githubusercontent.com/45361559/147854168-765c4b8c-0264-4407-b8ce-5f06006593e5.png)

Additional changes for post buttons:
Report and save post backend integration.
Share button copies the post link.

This should close #507.
