### PR TITLE
Android Privacy Switch Bug Fixed

### DIFF
--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/SelfProfilePageActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/SelfProfilePageActivity.java
@@ -178,6 +178,12 @@ public class SelfProfilePageActivity extends ToolbarActivity {
                     @Override
                     public void run() {
                         setUserFields();
+                        privateSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                            @Override
+                            public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                                privateSwitchController(b);
+                            }
+                        });
                     }
                 });
             }
@@ -191,12 +197,7 @@ public class SelfProfilePageActivity extends ToolbarActivity {
             }
         });
 
-        privateSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
-                privateSwitchController(b);
-            }
-        });
+
 
     }
 


### PR DESCRIPTION
The privacy switch was automatically sending a request while setting the initial value. Now this bug is fixed, the app only sends a request when the user clicks on the switch.

Related Issues: #558 