### PR TITLE
Android Activity Stream Connect

### DIFF
--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/ActivityStreamActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/ActivityStreamActivity.java
@@ -1,6 +1,8 @@
 package com.example.postory.activities;
 
 
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.fragment.app.FragmentPagerAdapter;
@@ -17,13 +19,20 @@ public class ActivityStreamActivity extends ToolbarActivity  {
 
     private TabLayout tabLayout;
     private ViewPager viewPager;
+    private SharedPreferences sharedPreferences;
     @Override
     protected void goHomeClicked() {
+        Intent i = new Intent(ActivityStreamActivity.this, MainActivity.class);
+        finish();
+        startActivity(i);
 
     }
 
     @Override
     protected void goCreatePostClicked() {
+        Intent createPostIntent = new Intent(ActivityStreamActivity.this, CreatePostActivity.class);
+        createPostIntent.putExtra("goal", "create");
+        startActivity(createPostIntent);
 
     }
 
@@ -34,16 +43,29 @@ public class ActivityStreamActivity extends ToolbarActivity  {
 
     @Override
     protected void goExploreClicked() {
-
+        Intent i = new Intent(ActivityStreamActivity.this, ExploreActivity.class);
+        startActivity(i);
     }
-
     @Override
     protected void goProfileClicked() {
-
+        Intent i = new Intent(ActivityStreamActivity.this, SelfProfilePageActivity.class);
+        startActivity(i);
     }
 
     @Override
     protected void logoutClicked() {
+        sharedPreferences = getSharedPreferences("MY_APP",MODE_PRIVATE);
+        sharedPreferences.edit().remove("valid_until").apply();
+        sharedPreferences.edit().remove("user_id").apply();
+        sharedPreferences.edit().remove("access_token").apply();
+        Intent i = new Intent(ActivityStreamActivity.this, LoginActivity.class);
+        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(i);
+    }
+    @Override
+    protected void goActivitiesClicked() {
 
     }
 
@@ -53,7 +75,7 @@ public class ActivityStreamActivity extends ToolbarActivity  {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_activity_stream);
         super.initToolbar();
-
+        sharedPreferences = getSharedPreferences("MY_APP",MODE_PRIVATE);
         tabLayout = (TabLayout) findViewById(R.id.tab_layout);
         viewPager = (ViewPager) findViewById(R.id.view_pager);
 

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/CreatePostActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/CreatePostActivity.java
@@ -934,6 +934,12 @@ public class CreatePostActivity extends ToolbarActivity {
     }
 
     @Override
+    protected void goActivitiesClicked() {
+        Intent i = new Intent(CreatePostActivity.this, ActivityStreamActivity.class);
+        startActivity(i);
+    }
+
+    @Override
     protected void goHomeClicked() {
         Intent i = new Intent(CreatePostActivity.this, MainActivity.class);
         finish();

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/ExploreActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/ExploreActivity.java
@@ -660,4 +660,9 @@ public class ExploreActivity extends  ToolbarActivity implements OnMapReadyCallb
 
 
     }
+    @Override
+    protected void goActivitiesClicked() {
+        Intent i = new Intent(ExploreActivity.this, ActivityStreamActivity.class);
+        startActivity(i);
+    }
 }

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/ListFilteredPostsActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/ListFilteredPostsActivity.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -137,5 +138,11 @@ public class ListFilteredPostsActivity extends ToolbarActivity{
 
         Intent intent = new Intent(ListFilteredPostsActivity.this, ExploreActivity.class);
         startActivity(intent);
+    }
+
+    @Override
+    protected void goActivitiesClicked() {
+        Intent i = new Intent(ListFilteredPostsActivity.this, ActivityStreamActivity.class);
+        startActivity(i);
     }
 }

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/MainActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/MainActivity.java
@@ -71,13 +71,8 @@ public class MainActivity extends ToolbarActivity {
 
     @Override
     protected void goCreatePostClicked() {
-        /*
         Intent createPostIntent = new Intent(MainActivity.this, CreatePostActivity.class);
         createPostIntent.putExtra("goal", "create");
-        startActivity(createPostIntent);
-         */
-
-        Intent createPostIntent = new Intent(MainActivity.this, ActivityStreamActivity.class);
         startActivity(createPostIntent);
     }
 

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/MainActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/MainActivity.java
@@ -150,4 +150,10 @@ public class MainActivity extends ToolbarActivity {
         byte[] b = baos.toByteArray();
         return Base64.encodeToString(b, Base64.DEFAULT);
     }
+
+    @Override
+    protected void goActivitiesClicked() {
+        Intent i = new Intent(MainActivity.this, ActivityStreamActivity.class);
+        startActivity(i);
+    }
 }

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/OtherProfilePageActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/OtherProfilePageActivity.java
@@ -306,4 +306,9 @@ public class OtherProfilePageActivity extends ToolbarActivity {
             }
         });
     }
+    @Override
+    protected void goActivitiesClicked() {
+        Intent i = new Intent(OtherProfilePageActivity.this, ActivityStreamActivity.class);
+        startActivity(i);
+    }
 }

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/SelfProfilePageActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/SelfProfilePageActivity.java
@@ -521,4 +521,10 @@ public class SelfProfilePageActivity extends ToolbarActivity {
     protected void goProfileClicked() {
         return;
     }
+
+    @Override
+    protected void goActivitiesClicked() {
+        Intent i = new Intent(SelfProfilePageActivity.this, ActivityStreamActivity.class);
+        startActivity(i);
+    }
 }

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/SinglePostActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/SinglePostActivity.java
@@ -614,4 +614,10 @@ public class SinglePostActivity extends ToolbarActivity{
         SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
         return formatter.format(d);
     }
+
+    @Override
+    protected void goActivitiesClicked() {
+        Intent i = new Intent(SinglePostActivity.this, ActivityStreamActivity.class);
+        startActivity(i);
+    }
 }

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/ToolbarActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/ToolbarActivity.java
@@ -37,6 +37,9 @@ public abstract class ToolbarActivity extends AppCompatActivity {
 
     protected abstract void logoutClicked();
 
+    protected abstract void goActivitiesClicked();
+
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -95,6 +98,10 @@ public abstract class ToolbarActivity extends AppCompatActivity {
                 return true;
             case R.id.logout:
                 logoutClicked();
+                return true;
+
+            case R.id.go_activities:
+                goActivitiesClicked();
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/UserSearchActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/UserSearchActivity.java
@@ -147,4 +147,9 @@ public class UserSearchActivity extends ToolbarActivity {
         });
 
     }
+    @Override
+    protected void goActivitiesClicked() {
+        Intent i = new Intent(UserSearchActivity.this, ActivityStreamActivity.class);
+        startActivity(i);
+    }
 }

--- a/postory/android/Postory/app/src/main/res/menu/toolbar_menu.xml
+++ b/postory/android/Postory/app/src/main/res/menu/toolbar_menu.xml
@@ -15,7 +15,7 @@
     <item
         android:id="@+id/go_explore"
         android:icon="@drawable/baseline_world_black_24dp"
-        android:title="TODO"
+        android:title="Discover"
         app:showAsAction="always" />
 
     <item
@@ -34,6 +34,9 @@
         app:actionViewClass="android.widget.SearchView"
         app:showAsAction="collapseActionView|ifRoom" />
 
+    <item
+        android:id="@+id/go_activities"
+        android:title="Activities" />
 
     <item
         android:id="@+id/logout"


### PR DESCRIPTION
Activity streams page is connected to the toolbar and activity streams page can link to other pages via toolbar. MainActivity was redirecting to ActivityStreamsActivity instead of CreatePostActivity from the toolbar. This was done for easy testing. Now MainActivity also redirects to CreatePostActivity from the correct button at toolbar.

Related Issues:  #561 