### PR TITLE
Android progress dialogs are added for report operations

### DIFF
--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/OtherProfilePageActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/OtherProfilePageActivity.java
@@ -19,6 +19,7 @@ import com.bumptech.glide.request.RequestOptions;
 import com.example.postory.BuildConfig;
 import com.example.postory.R;
 import com.example.postory.adapters.PostAdapter;
+import com.example.postory.dialogs.DelayedProgressDialog;
 import com.example.postory.models.Post;
 import com.example.postory.models.UserModel;
 import com.github.johnpersano.supertoasts.library.Style;
@@ -64,6 +65,8 @@ public class OtherProfilePageActivity extends ToolbarActivity {
     public static final String TAG = "OtherProfilePageActivity";
     private Post[] posts;
     private boolean followed;
+
+    private DelayedProgressDialog dialog;
 
     @Override
     protected void goProfileClicked() {
@@ -125,6 +128,7 @@ public class OtherProfilePageActivity extends ToolbarActivity {
         profilePicture = (ImageView) findViewById(R.id.profilePicture);
         report = (ImageView) findViewById(R.id.report);
 
+        dialog = new DelayedProgressDialog();
         sharedPreferences = getSharedPreferences("MY_APP", MODE_PRIVATE);
         accessToken = sharedPreferences.getString("access_token", "");
         int viewerId = Integer.parseInt(sharedPreferences.getString("user_id", ""));
@@ -172,6 +176,7 @@ public class OtherProfilePageActivity extends ToolbarActivity {
         report.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                dialog.show(getSupportFragmentManager(),"The user is being reported...");
                 String url = BuildConfig.API_IP + "/user/report/user/" + userId;
                 MultipartBody.Builder bodyBuilder = new MultipartBody.Builder();
                 MultipartBody.Builder builder = bodyBuilder.setType(MultipartBody.FORM);
@@ -187,6 +192,12 @@ public class OtherProfilePageActivity extends ToolbarActivity {
                     @Override
                     public void onFailure(@NotNull Call call, @NotNull IOException e) {
                         Log.i(TAG, "onFailure: ");
+                        runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                dialog.cancel();
+                            }
+                        });
                     }
 
                     @Override
@@ -195,6 +206,7 @@ public class OtherProfilePageActivity extends ToolbarActivity {
                             runOnUiThread(new Runnable() {
                                 @Override
                                 public void run() {
+                                    dialog.cancel();
                                     SuperActivityToast.create(OtherProfilePageActivity.this, new Style(), Style.TYPE_BUTTON)
                                             .setProgressBarColor(Color.WHITE)
                                             .setText("The user is reported.")

--- a/postory/android/Postory/app/src/main/java/com/example/postory/activities/SinglePostActivity.java
+++ b/postory/android/Postory/app/src/main/java/com/example/postory/activities/SinglePostActivity.java
@@ -21,6 +21,7 @@ import com.example.postory.adapters.CommentsAdapter;
 import com.example.postory.adapters.LocationAdapter;
 import com.example.postory.adapters.PostAdapter;
 import com.example.postory.adapters.TagsAdapter;
+import com.example.postory.dialogs.DelayedProgressDialog;
 import com.example.postory.fragments.MapFragment;
 import com.example.postory.models.*;
 import com.example.postory.utils.TimeController;
@@ -81,6 +82,8 @@ public class SinglePostActivity extends ToolbarActivity{
     String selfId;
     int likeCount = 0;
     boolean liked = false;
+
+    private DelayedProgressDialog dialog;
 
     public static final MediaType JSON
             = MediaType.parse("application/json; charset=utf-8");
@@ -164,6 +167,7 @@ public class SinglePostActivity extends ToolbarActivity{
         commentsList = (ListView) findViewById(R.id.comments_section);
         report = (ImageView) findViewById(R.id.report);
 
+        dialog = new DelayedProgressDialog();
 
         likeLayout.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -340,6 +344,7 @@ public class SinglePostActivity extends ToolbarActivity{
         report.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                dialog.show(getSupportFragmentManager(),"The post is being reported.");
                 String url = BuildConfig.API_IP + "/user/report/story/" + postId ;
                 MultipartBody.Builder bodyBuilder = new MultipartBody.Builder();
                 MultipartBody.Builder builder = bodyBuilder.setType(MultipartBody.FORM);
@@ -354,6 +359,12 @@ public class SinglePostActivity extends ToolbarActivity{
                 client.newCall(reportRequest).enqueue(new Callback() {
                     @Override
                     public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                        runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                dialog.cancel();
+                            }
+                        });
                         Log.i(TAG, "onFailure: ");
                     }
 
@@ -363,6 +374,7 @@ public class SinglePostActivity extends ToolbarActivity{
                             runOnUiThread(new Runnable() {
                                 @Override
                                 public void run() {
+                                    dialog.cancel();
                                     SuperActivityToast.create(SinglePostActivity.this, new Style(), Style.TYPE_BUTTON)
                                             .setProgressBarColor(Color.WHITE)
                                             .setText("The post is reported.")


### PR DESCRIPTION
When the user reports a post or an user, a connection with API is established but it takes some time. I added progress dialogs to notify the user that she has to wait for this operation. This enhances user experience.

Related Issues: #564 